### PR TITLE
Simplify completion handling and suggestions

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,3 +1,12 @@
+# v0.4.1
+
+## Key Features
+
+## Code changes
+
+## Related issues
+
+
 # v0.4.0
 
 ## Key Features
@@ -11,6 +20,12 @@
 
 - Clarify README `opts` struct tag documentation
 - Add note in README for setting up bash completion compatibility in zsh
+
+
+## Code changes
+
+- Add enumer command (#8)
+- Add support for custom value parser define on pointer type (#7)
 
 
 # v0.3.1

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,6 +1,16 @@
-# v0.4.1
+# v0.5.0
 
 ## Key Features
+
+- Simplify completion option and associated interface to a simple list of
+  strings
+- Handle special case in zsh completions, discard `COMP_WORD=--` when not
+  matching start of argument at `COMP_INDEX`
+- Change available completion helper functions to:
+    - `DefaultCompletion()` to return the default completion behavior from a
+      custom completion handler
+    - `DefaultFilenameCompletion()` matching default shell completion
+    - `MatchingFilenameCompletion()` for pattern based filename matching
 
 ## Code changes
 
@@ -20,13 +30,6 @@
 
 - Clarify README `opts` struct tag documentation
 - Add note in README for setting up bash completion compatibility in zsh
-
-
-## Code changes
-
-- Add enumer command (#8)
-- Add support for custom value parser define on pointer type (#7)
-
 
 # v0.3.1
 

--- a/cli.go
+++ b/cli.go
@@ -9,26 +9,11 @@ import (
 	"golang.org/x/term"
 
 	"github.com/maargenton/go-cli/pkg/cli"
-	"github.com/maargenton/go-cli/pkg/option"
 )
 
-// Command is the main public type used to define all the details of a comand to
-// be handled.
+// Command is the main public type used to define all the details of a command
+// to be handled.
 type Command = cli.Command
-
-// Suggestion is an alias of `option.Description` used to describe one
-// suggestions in the context of a completion request.
-type Suggestion = option.Description
-
-// SimpleSuggestionList generate a list of Suggestion objects with no
-// description from a list of strings
-func SimpleSuggestionList(options ...string) []Suggestion {
-	var r = make([]option.Description, 0, len(options))
-	for _, o := range options {
-		r = append(r, option.Description{Option: o})
-	}
-	return r
-}
 
 // DefaultCompletion acts like the shell default completion and suggests file
 // and folder names under the current directory. It is used by default when the
@@ -37,9 +22,14 @@ func SimpleSuggestionList(options ...string) []Suggestion {
 // suitable.
 var DefaultCompletion = cli.DefaultCompletion
 
-// FilepathCompletion implements a custom filepath completion scheme, matching
-// the provided pattern if possible.
-var FilepathCompletion = cli.FilepathCompletion
+// DefaultFilenameCompletion implements a default filename-based completion,
+// similar to the default shell completion.
+var DefaultFilenameCompletion = cli.DefaultFilenameCompletion
+
+// MatchingFileCompletion implements a custom filepath completion scheme,
+// matching the provided pattern if possible, using default filename completion
+// as a fallback.
+var MatchingFilenameCompletion = cli.MatchingFilenameCompletion
 
 // Run takes the command line arguments, parses them and execute the
 // command or sub-command with the corresponding options.
@@ -66,10 +56,9 @@ func Run(cmd *Command) {
 			fmt.Printf("%v\n", version)
 		}
 	} else if errors.Is(err, cli.ErrCompletionRequested) {
-		fmt.Printf("%v",
-			cli.FormatCompletionSuggestions(cmd.ConsoleWidth, cmd.Suggestions),
-		)
-		// cli.DumpCompletionSuggestions("competion.txt", cmd.Suggestions)
+		for _, v := range cmd.Suggestions {
+			fmt.Println(v)
+		}
 	} else if err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)
 		os.Exit(1)

--- a/pkg/cli/cmd.go
+++ b/pkg/cli/cmd.go
@@ -23,7 +23,7 @@ type Command struct {
 	ConsoleWidth      int
 	DisableCompletion bool
 
-	Suggestions []option.Description
+	Suggestions []string
 
 	opts *option.Set
 }
@@ -49,7 +49,7 @@ type UsageHandler interface {
 // CompletionHandler is an optional interface for the command handler to provide
 // meaningful values for a specific option or argument.
 type CompletionHandler interface {
-	Complete(opt *option.T, partial string) []option.Description
+	Complete(opt *option.T, partial string) []string
 }
 
 // ---------------------------------------------------------------------------

--- a/pkg/cli/completion.go
+++ b/pkg/cli/completion.go
@@ -1,7 +1,10 @@
 package cli
 
 import (
+	"encoding/json"
 	"fmt"
+	"io"
+	"os"
 	"strconv"
 	"strings"
 
@@ -25,60 +28,45 @@ func BashCompletionScript(command string) string {
 	return fmt.Sprintf(bashCompletionTemplate, command)
 }
 
-// FormatCompletionSuggestions takes pre-filtered completion suggestions and
-// returns a formatted string ready to pass back to the shell during a
-// completion request. The description and addition suffixes are dropped when
-// only one option is available.
-func FormatCompletionSuggestions(width int, suggestions []option.Description) string {
-	var s strings.Builder
-	if len(suggestions) == 1 {
-		v := suggestions[0].Option
-		v = strings.Split(v, " ")[0]
-		fmt.Fprintf(&s, "%v\n", v)
-	} else {
-		fmt.Fprintf(&s, "%v", option.FormatCompletion(width, suggestions))
-	}
-
-	return s.String()
+// DefaultCompletion implements a default completion for a given option field,
+// and can be used a fallback by command completion handlers. It handles
+// specific cases based on the option field type, and simulates default shell
+// behavior (filename completion) for string types.
+func DefaultCompletion(opt *option.T, w string) []string {
+	return DefaultFilenameCompletion(opt, w)
 }
 
-// DefaultCompletion acts like the shell default completion and suggests file
-// and folder names under the current directory. It is used by default when the
-// command does not implement a specific completion handler, and should be used
-// from the command completion handler when no other completion logic is
-// suitable.
-func DefaultCompletion(w string) []option.Description {
-	var r []option.Description
+// DefaultFilenameCompletion implements a default filename-based completion,
+// similar to the default shell completion.
+func DefaultFilenameCompletion(opt *option.T, w string) (r []string) {
 	files, err := dir.Glob(fmt.Sprintf("%v*", w))
 	if err == nil {
 		if len(files) == 1 && strings.HasSuffix(files[0], string(fileutils.Separator)) {
-			return DefaultCompletion(files[0])
+			return DefaultFilenameCompletion(opt, files[0])
 		}
 		for _, f := range files {
-			r = append(r, option.Description{Option: f})
+			r = append(r, f)
 		}
 	}
-	return r
+	return
 }
 
-// FilepathCompletion implements a custom filepath completion scheme, matching
-// the provided pattern if possible. If the pattern does not yield any result,
-// or if none of the suggestions match the partial argument being completed,
-// then if folds back to the default filename completion.
-func FilepathCompletion(pattern string, w string) []option.Description {
+// MatchingFileCompletion implements a custom filepath completion scheme,
+// matching the provided pattern if possible, using default filename completion
+// as a fallback.
+func MatchingFilenameCompletion(opt *option.T, pattern string, w string) (r []string) {
 	files, err := dir.Glob(pattern)
 	if err == nil {
-		var r []option.Description
 		for _, f := range files {
 			if strings.HasPrefix(f, w) {
-				r = append(r, option.Description{Option: f})
+				r = append(r, f)
 			}
 		}
 		if len(r) > 0 {
 			return r
 		}
 	}
-	return DefaultCompletion(w)
+	return DefaultFilenameCompletion(opt, w)
 }
 
 // ---
@@ -87,6 +75,10 @@ func (cmd *Command) handleCompletionRequest() bool {
 	i, w := checkCompletionRequest(cmd.ProcessEnv)
 	if i == 0 {
 		return false
+	}
+
+	if w == "--" {
+		w = ""
 	}
 
 	// Trim process arguments past the completion point
@@ -99,28 +91,30 @@ func (cmd *Command) handleCompletionRequest() bool {
 	}
 
 	var comp = cmd.opts.GetCompletion(args, w)
-	if comp.Opt != nil {
-		comp.OptValues = cmd.complete(comp.Opt, w)
+	if comp.OptRef != nil {
+		comp.OptValues = cmd.complete(comp.OptRef, w)
 	}
-	if comp.Arg != nil {
-		comp.ArgValues = cmd.complete(comp.Arg, w)
+	if comp.ArgRef != nil {
+		comp.ArgValues = cmd.complete(comp.ArgRef, w)
 	}
 
 	for _, o := range comp.Options {
-		if strings.HasPrefix(o.Option, w) {
+		if strings.HasPrefix(o, w) {
 			cmd.Suggestions = append(cmd.Suggestions, o)
 		}
 	}
 	for _, o := range comp.OptValues {
-		if strings.HasPrefix(o.Option, w) {
+		if strings.HasPrefix(o, w) {
 			cmd.Suggestions = append(cmd.Suggestions, o)
 		}
 	}
 	for _, o := range comp.ArgValues {
-		if strings.HasPrefix(o.Option, w) {
+		if strings.HasPrefix(o, w) {
 			cmd.Suggestions = append(cmd.Suggestions, o)
 		}
 	}
+
+	dumpCompletionRequest(comp)
 
 	return true
 }
@@ -137,9 +131,29 @@ func checkCompletionRequest(env map[string]string) (index int, word string) {
 	return
 }
 
-func (cmd *Command) complete(opt *option.T, word string) []option.Description {
+func dumpCompletionRequest(comp option.Completion) {
+	if s, ok := os.LookupEnv("COMPLETION_DEBUG_OUTPUT"); ok && s != "" {
+		type obj = map[string]interface{}
+		var v = obj{
+			"args": os.Args,
+			"env": obj{
+				"COMP_INDEX": os.Getenv("COMP_INDEX"),
+				"COMP_WORD":  os.Getenv("COMP_WORD"),
+			},
+			"comp": comp,
+		}
+
+		fileutils.WriteFile(s, func(w io.Writer) error {
+			var e = json.NewEncoder(w)
+			e.SetIndent("", "    ")
+			return e.Encode(v)
+		})
+	}
+}
+
+func (cmd *Command) complete(opt *option.T, word string) []string {
 	if handler, ok := cmd.Handler.(CompletionHandler); ok {
 		return handler.Complete(opt, word)
 	}
-	return DefaultCompletion(word)
+	return DefaultCompletion(opt, word)
 }

--- a/pkg/cli/completion.go
+++ b/pkg/cli/completion.go
@@ -132,6 +132,13 @@ func (cmd *Command) getCompletionRequest() (index int, word string) {
 	return
 }
 
+func (cmd *Command) complete(opt *option.T, word string) []string {
+	if handler, ok := cmd.Handler.(CompletionHandler); ok {
+		return handler.Complete(opt, word)
+	}
+	return DefaultCompletion(opt, word)
+}
+
 func dumpCompletionRequest(comp option.Completion) {
 	if s, ok := os.LookupEnv("COMPLETION_DEBUG_OUTPUT"); ok && s != "" {
 		type obj = map[string]interface{}
@@ -150,11 +157,4 @@ func dumpCompletionRequest(comp option.Completion) {
 			return e.Encode(v)
 		})
 	}
-}
-
-func (cmd *Command) complete(opt *option.T, word string) []string {
-	if handler, ok := cmd.Handler.(CompletionHandler); ok {
-		return handler.Complete(opt, word)
-	}
-	return DefaultCompletion(opt, word)
 }

--- a/pkg/cli/completion.go
+++ b/pkg/cli/completion.go
@@ -72,13 +72,9 @@ func MatchingFilenameCompletion(opt *option.T, pattern string, w string) (r []st
 // ---
 
 func (cmd *Command) handleCompletionRequest() bool {
-	i, w := checkCompletionRequest(cmd.ProcessEnv)
+	i, w := cmd.getCompletionRequest()
 	if i == 0 {
 		return false
-	}
-
-	if w == "--" {
-		w = ""
 	}
 
 	// Trim process arguments past the completion point
@@ -119,14 +115,19 @@ func (cmd *Command) handleCompletionRequest() bool {
 	return true
 }
 
-func checkCompletionRequest(env map[string]string) (index int, word string) {
-	i, ok := env["COMP_INDEX"]
-	w, ok2 := env["COMP_WORD"]
-	if ok && ok2 {
-		if ii, err := strconv.ParseInt(i, 0, 0); err == nil {
+func (cmd *Command) getCompletionRequest() (index int, word string) {
+	var env = cmd.ProcessEnv
+
+	word = env["COMP_WORD"]
+	if ii, ok := env["COMP_INDEX"]; ok {
+		if ii, err := strconv.ParseInt(ii, 0, 0); err == nil {
 			index = int(ii)
-			word = w
 		}
+	}
+
+	var args = cmd.ProcessArgs[:]
+	if index == 0 || index >= len(args) || !strings.HasPrefix(args[index], word) {
+		word = ""
 	}
 	return
 }

--- a/pkg/cli/completion_test.go
+++ b/pkg/cli/completion_test.go
@@ -3,6 +3,8 @@ package cli_test
 import (
 	"testing"
 
+	"github.com/maargenton/go-fileutils"
+	"github.com/maargenton/go-testpredicate/pkg/bdd"
 	"github.com/maargenton/go-testpredicate/pkg/require"
 
 	"github.com/maargenton/go-cli/pkg/cli"
@@ -18,24 +20,24 @@ func TestBashCompletionScript(t *testing.T) {
 }
 
 func TestDefaultCompletion(t *testing.T) {
-	t.Run("Given the current directory structure", func(t *testing.T) {
-		t.Run("when Calling DefaultCompletion() with an empty string", func(t *testing.T) {
+	bdd.Given(t, "the current directory structure", func(t *bdd.T) {
+		t.When("calling DefaultCompletion() with an empty string", func(t *bdd.T) {
 			suggestions := cli.DefaultCompletion(nil, "")
-			t.Run("then suggestions include the local files", func(t *testing.T) {
+			t.Then("suggestions include the local files", func(t *bdd.T) {
 				require.That(t, suggestions).IsSupersetOf(
 					[]string{"completion.go", "completion_test.go"})
 			})
 		})
-		t.Run("when Calling DefaultCompletion() with partial filename", func(t *testing.T) {
+		t.When("calling DefaultCompletion() with partial filename", func(t *bdd.T) {
 			suggestions := cli.DefaultCompletion(nil, "comp")
-			t.Run("then suggestions include only the matching files", func(t *testing.T) {
+			t.Then("suggestions include only the matching files", func(t *bdd.T) {
 				require.That(t, suggestions).IsEqualSet(
 					[]string{"completion.go", "completion_test.go"})
 			})
 		})
-		t.Run("when Calling DefaultCompletion() with partial unique folder name", func(t *testing.T) {
+		t.When("calling DefaultCompletion() with partial unique folder name", func(t *bdd.T) {
 			suggestions := cli.DefaultCompletion(nil, "../cl")
-			t.Run("then suggestions include the files in that folder", func(t *testing.T) {
+			t.Then("suggestions include the files in that folder", func(t *bdd.T) {
 				require.That(t, suggestions).IsSupersetOf([]string{
 					"../cli/completion.go",
 					"../cli/completion_test.go",
@@ -46,27 +48,27 @@ func TestDefaultCompletion(t *testing.T) {
 }
 
 func TestMatchingFilenameCompletion(t *testing.T) {
-	t.Run("Given a call to MatchingFilenameCompletion()", func(t *testing.T) {
-		t.Run("when passing a pattern and an empty string", func(t *testing.T) {
+	bdd.Given(t, "a call to MatchingFilenameCompletion()", func(t *bdd.T) {
+		t.When("passing a pattern and an empty string", func(t *bdd.T) {
 			suggestions := cli.MatchingFilenameCompletion(nil, "*_test.go", "")
 
-			t.Run("then suggestions include all filenames matching the pattern", func(t *testing.T) {
+			t.Then("suggestions include all filenames matching the pattern", func(t *bdd.T) {
 				require.That(t, suggestions).IsEqualSet(
 					[]string{"cmd_test.go", "completion_test.go"})
 			})
 		})
-		t.Run("when passing a pattern and a partial name", func(t *testing.T) {
+		t.When("passing a pattern and a partial name", func(t *bdd.T) {
 			suggestions := cli.MatchingFilenameCompletion(nil, "*_test.go", "co")
 
-			t.Run("then suggestions include only filenames matching both", func(t *testing.T) {
+			t.Then("suggestions include only filenames matching both", func(t *bdd.T) {
 				require.That(t, suggestions).IsEqualSet(
 					[]string{"completion_test.go"})
 			})
 		})
-		t.Run("when passing a pattern and a non-matching partial name", func(t *testing.T) {
+		t.When("passing a pattern and a non-matching partial name", func(t *bdd.T) {
 			suggestions := cli.MatchingFilenameCompletion(nil, "*_test.go", "er")
 
-			t.Run("then the pattern is ignored and all matching files are returned", func(t *testing.T) {
+			t.Then("the pattern is ignored and all matching files are returned", func(t *bdd.T) {
 				require.That(t, suggestions).IsEqualSet(
 					[]string{"errors.go"})
 			})
@@ -104,14 +106,14 @@ func (c *compCmd2) Complete(opt *option.T, partial string) []string {
 }
 
 func TestCommandRunCompletion(t *testing.T) {
-	t.Run("Given a well defined command struct", func(t *testing.T) {
+	bdd.Given(t, "a well defined command struct", func(t *bdd.T) {
 		var cmd = &cli.Command{
 			Handler:     &compCmd{},
 			Description: "command description",
 		}
 		var c = cmd.Handler.(*compCmd)
 
-		t.Run("when calling Run() with completion request and partial option flag", func(t *testing.T) {
+		t.When("calling Run() with completion request and partial option flag", func(t *bdd.T) {
 			cmd.ProcessArgs = []string{"command-name", "-v", "--o"}
 			cmd.ProcessEnv = map[string]string{
 				"COMP_WORD":  "--o",
@@ -120,19 +122,19 @@ func TestCommandRunCompletion(t *testing.T) {
 			cmd.Suggestions = nil
 			err := cmd.Run()
 
-			t.Run("then the command is not run", func(t *testing.T) {
+			t.Then("the command is not run", func(t *bdd.T) {
 				require.That(t, c.didRun).IsFalse()
 			})
-			t.Run("then the completion request error is returned", func(t *testing.T) {
+			t.Then("the completion request error is returned", func(t *bdd.T) {
 				require.That(t, err).IsError(cli.ErrCompletionRequested)
 			})
-			t.Run("then the suggestions contain the matching flag", func(t *testing.T) {
+			t.Then("the suggestions contain the matching flag", func(t *bdd.T) {
 				require.That(t, cmd.Suggestions).Length().Eq(1)
 				require.That(t, cmd.Suggestions[0]).StartsWith("--option")
 			})
 		})
 
-		t.Run("when calling Run() with a partial option argument", func(t *testing.T) {
+		t.When("calling Run() with a partial option argument", func(t *bdd.T) {
 			cmd.ProcessArgs = []string{"command-name", "-v", "--option", "co"}
 			cmd.ProcessEnv = map[string]string{
 				"COMP_WORD":  "co",
@@ -141,19 +143,19 @@ func TestCommandRunCompletion(t *testing.T) {
 			cmd.Suggestions = nil
 			err := cmd.Run()
 
-			t.Run("then the command is not run", func(t *testing.T) {
+			t.Then("the command is not run", func(t *bdd.T) {
 				require.That(t, c.didRun).IsFalse()
 			})
-			t.Run("then the completion request error is returned", func(t *testing.T) {
+			t.Then("the completion request error is returned", func(t *bdd.T) {
 				require.That(t, err).IsError(cli.ErrCompletionRequested)
 			})
-			t.Run("then the suggestions contain matching local filenames", func(t *testing.T) {
+			t.Then("the suggestions contain matching local filenames", func(t *bdd.T) {
 				require.That(t, cmd.Suggestions).IsSupersetOf(
 					[]string{"completion.go", "completion_test.go"})
 			})
 		})
 
-		t.Run("when calling Run() with nothing", func(t *testing.T) {
+		t.When("calling Run() with nothing", func(t *bdd.T) {
 			cmd.ProcessArgs = []string{"command-name"}
 			cmd.ProcessEnv = map[string]string{
 				"COMP_WORD":  "",
@@ -162,24 +164,24 @@ func TestCommandRunCompletion(t *testing.T) {
 			cmd.Suggestions = nil
 			err := cmd.Run()
 
-			t.Run("then the command is not run", func(t *testing.T) {
+			t.Then("the command is not run", func(t *bdd.T) {
 				require.That(t, c.didRun).IsFalse()
 			})
-			t.Run("then the completion request error is returned", func(t *testing.T) {
+			t.Then("the completion request error is returned", func(t *bdd.T) {
 				require.That(t, err).IsError(cli.ErrCompletionRequested)
 			})
-			t.Run("then the suggestions include option flags", func(t *testing.T) {
+			t.Then("the suggestions include option flags", func(t *bdd.T) {
 				require.That(t, cmd.Suggestions).IsSupersetOf(
 					[]string{"--verbose", "--option"})
 			})
-			t.Run("then the suggestions include argument options", func(t *testing.T) {
+			t.Then("the suggestions include argument options", func(t *bdd.T) {
 				require.That(t, cmd.Suggestions).IsSupersetOf(
 					[]string{"completion.go", "completion_test.go"})
 			})
 		})
 	})
 
-	t.Run("Given a command with custom completion handler", func(t *testing.T) {
+	bdd.Given(t, "a command with custom completion handler", func(t *bdd.T) {
 		var cmd = &cli.Command{
 			Handler:     &compCmd2{},
 			Description: "command description",
@@ -187,7 +189,7 @@ func TestCommandRunCompletion(t *testing.T) {
 		var c = cmd.Handler.(*compCmd2)
 		_ = c
 
-		t.Run("when calling Run() with nothing", func(t *testing.T) {
+		t.When("calling Run() with nothing", func(t *bdd.T) {
 			cmd.ProcessArgs = []string{"command-name"}
 			cmd.ProcessEnv = map[string]string{
 				"COMP_WORD":  "",
@@ -196,23 +198,23 @@ func TestCommandRunCompletion(t *testing.T) {
 			cmd.Suggestions = nil
 			err := cmd.Run()
 
-			t.Run("then the command is not run", func(t *testing.T) {
+			t.Then("the command is not run", func(t *bdd.T) {
 				require.That(t, c.didRun).IsFalse()
 			})
-			t.Run("then the completion request error is returned", func(t *testing.T) {
+			t.Then("the completion request error is returned", func(t *bdd.T) {
 				require.That(t, err).IsError(cli.ErrCompletionRequested)
 			})
-			t.Run("then the suggestions include option flags", func(t *testing.T) {
+			t.Then("the suggestions include option flags", func(t *bdd.T) {
 				require.That(t, cmd.Suggestions).IsSupersetOf(
 					[]string{"--verbose", "--option"})
 			})
-			t.Run("then the suggestions include argument options", func(t *testing.T) {
+			t.Then("the suggestions include argument options", func(t *bdd.T) {
 				require.That(t, cmd.Suggestions).IsSupersetOf(
 					[]string{"ddd", "eee", "fff"})
 			})
 		})
 
-		t.Run("when calling Run() with missing option argument", func(t *testing.T) {
+		t.When("calling Run() with missing option argument", func(t *bdd.T) {
 			cmd.ProcessArgs = []string{"command-name", "-v", "--option"}
 			cmd.ProcessEnv = map[string]string{
 				"COMP_WORD":  "",
@@ -221,11 +223,35 @@ func TestCommandRunCompletion(t *testing.T) {
 			cmd.Suggestions = nil
 			cmd.Run()
 
-			t.Run("then the suggestions contain matching local filenames", func(t *testing.T) {
+			t.Then("the suggestions contain matching local filenames", func(t *bdd.T) {
 				require.That(t, cmd.Suggestions).IsEqualSet(
 					[]string{"aaa", "bbb", "ccc"})
 			})
 		})
 	})
+}
 
+func TestCommandRunCompletionDebuf(t *testing.T) {
+
+	bdd.Given(t, "an environment with COMPLETION_DEBUG_OUTPUT set", func(t *bdd.T) {
+		var cmd = &cli.Command{Handler: &compCmd{}}
+		var tmp = t.TempDir()
+		var filename = fileutils.Join(tmp, "comp.json")
+		t.Setenv("COMPLETION_DEBUG_OUTPUT", filename)
+
+		t.When("calling Run() with completion request", func(t *bdd.T) {
+			cmd.ProcessArgs = []string{"command-name", "-v", "--o"}
+			cmd.ProcessEnv = map[string]string{
+				"COMP_WORD":  "--o",
+				"COMP_INDEX": "2",
+			}
+			cmd.Suggestions = nil
+			err := cmd.Run()
+
+			t.Then("the specified file is created", func(t *bdd.T) {
+				require.That(t, fileutils.Exists(filename)).IsTrue()
+				require.That(t, err).IsError(cli.ErrCompletionRequested)
+			})
+		})
+	})
 }

--- a/pkg/option/completion.go
+++ b/pkg/option/completion.go
@@ -7,21 +7,19 @@ import (
 // Completion records a set of completion suggestions, including usable flags,
 // values for a specific flag and / or values for next remaining argument.
 type Completion struct {
-	Options   []Description
-	Opt       *T
-	OptValues []Description
-	Arg       *T
-	ArgValues []Description
+	Options   []string
+	OptValues []string
+	ArgValues []string
+	OptRef    *T
+	ArgRef    *T
 }
 
 // GetCompletion evaluate the list of command line arguments `args` in the
 // context of the receiver, and determines a list of completion suggestions for
 // the `partial` argument given. The result is a partially filled `Completion`
 // object with either a list of `Options` or one of `Opt` or `Arg` set the the
-// `option.T` whose value ned to be completee.
-func (opts *Set) GetCompletion(args []string, partial string) Completion {
-
-	var suggestions Completion
+// `option.T` whose value needs to be completed.
+func (opts *Set) GetCompletion(args []string, partial string) (r Completion) {
 
 	// Evaluate commandline arguments, discarding values
 	var opt *T
@@ -61,15 +59,15 @@ func (opts *Set) GetCompletion(args []string, partial string) Completion {
 	}
 
 	if opt != nil {
-		suggestions.Opt = opt
-		return suggestions
+		r.OptRef = opt
+		return r
 	}
 
 	var nonExclusiveUsed = len(remainingArgs) > 0
 	for o := range usedOptions {
 		if o.Type == Special {
 			// Exclusive flag has been used, nothing more to suggest
-			return suggestions
+			return r
 		}
 		nonExclusiveUsed = true
 	}
@@ -79,15 +77,15 @@ func (opts *Set) GetCompletion(args []string, partial string) Completion {
 				// Non-exclusive flag has been used, skip special flags
 				continue
 			}
-			suggestions.Options = append(suggestions.Options, o.GetCompletionUsage())
+			r.Options = append(r.Options, o.Name())
 		}
 	}
 
 	if len(remainingArgs) < len(opts.Positional) {
-		suggestions.Arg = opts.Positional[len(remainingArgs)]
+		r.ArgRef = opts.Positional[len(remainingArgs)]
 	} else if opts.Args != nil {
-		suggestions.Arg = opts.Args
+		r.ArgRef = opts.Args
 	}
 
-	return suggestions
+	return r
 }

--- a/pkg/option/completion_test.go
+++ b/pkg/option/completion_test.go
@@ -37,11 +37,11 @@ func TestGetCompletion(t *testing.T) {
 			completion := optionSet.GetCompletion(args, partial)
 
 			t.Run("then no specific option is being completed", func(t *testing.T) {
-				require.That(t, completion.Opt).IsNil()
+				require.That(t, completion.OptRef).IsNil()
 				require.That(t, completion.OptValues).IsEmpty()
 			})
 			t.Run("then the first argument is being completed", func(t *testing.T) {
-				require.That(t, completion.Arg).Eq(optionSet.Positional[0])
+				require.That(t, completion.ArgRef).Eq(optionSet.Positional[0])
 			})
 			t.Run("then available options are listed", func(t *testing.T) {
 				require.That(t, completion.Options).Length().Eq(5)
@@ -55,8 +55,8 @@ func TestGetCompletion(t *testing.T) {
 
 			t.Run("then only yhe option is returned", func(t *testing.T) {
 				var expected = optionSet.GetOption("baudrate")
-				require.That(t, completion.Opt).Eq(expected)
-				require.That(t, completion.Arg).IsNil()
+				require.That(t, completion.OptRef).Eq(expected)
+				require.That(t, completion.ArgRef).IsNil()
 				require.That(t, completion.Options).IsEmpty()
 			})
 		})
@@ -67,12 +67,12 @@ func TestGetCompletion(t *testing.T) {
 			completion := optionSet.GetCompletion(args, partial)
 
 			t.Run("then remaining options are listed", func(t *testing.T) {
-				require.That(t, completion.Opt).IsNil()
-				require.That(t, completion.Options).Field("Option").IsEqualSet(
-					[]string{"--format <value>", "-v"})
+				require.That(t, completion.OptRef).IsNil()
+				require.That(t, completion.Options).IsEqualSet(
+					[]string{"--format", "-v"})
 			})
 			t.Run("then the first argument is being completed", func(t *testing.T) {
-				require.That(t, completion.Arg).Eq(optionSet.Positional[0])
+				require.That(t, completion.ArgRef).Eq(optionSet.Positional[0])
 			})
 		})
 
@@ -82,12 +82,12 @@ func TestGetCompletion(t *testing.T) {
 			completion := optionSet.GetCompletion(args, partial)
 
 			t.Run("then remaining options are listed", func(t *testing.T) {
-				require.That(t, completion.Opt).IsNil()
-				require.That(t, completion.Options).Field("Option").IsEqualSet(
-					[]string{"--format <value>", "-v"})
+				require.That(t, completion.OptRef).IsNil()
+				require.That(t, completion.Options).IsEqualSet(
+					[]string{"--format", "-v"})
 			})
 			t.Run("then the first argument is being completed", func(t *testing.T) {
-				require.That(t, completion.Arg).Eq(optionSet.Positional[0])
+				require.That(t, completion.ArgRef).Eq(optionSet.Positional[0])
 			})
 		})
 
@@ -97,8 +97,8 @@ func TestGetCompletion(t *testing.T) {
 			completion := optionSet.GetCompletion(args, partial)
 
 			t.Run("then remaining options are listed", func(t *testing.T) {
-				require.That(t, completion.Opt).IsNil()
-				require.That(t, completion.Arg).IsNil()
+				require.That(t, completion.OptRef).IsNil()
+				require.That(t, completion.ArgRef).IsNil()
 				require.That(t, completion.Options).IsEmpty()
 			})
 		})
@@ -109,12 +109,12 @@ func TestGetCompletion(t *testing.T) {
 			completion := optionSet.GetCompletion(args, partial)
 
 			t.Run("then remaining options are listed", func(t *testing.T) {
-				require.That(t, completion.Opt).IsNil()
-				require.That(t, completion.Options).Field("Option").IsEqualSet(
-					[]string{"--format <value>", "-v", "--timestamp"})
+				require.That(t, completion.OptRef).IsNil()
+				require.That(t, completion.Options).IsEqualSet(
+					[]string{"--format", "-v", "--timestamp"})
 			})
 			t.Run("then next argument is being completed", func(t *testing.T) {
-				require.That(t, completion.Arg).Eq(optionSet.Args)
+				require.That(t, completion.ArgRef).Eq(optionSet.Args)
 			})
 		})
 	})

--- a/pkg/option/option.go
+++ b/pkg/option/option.go
@@ -106,29 +106,6 @@ func (opt *T) GetUsage() (usage Description) {
 	}
 }
 
-// GetCompletionUsage returns a value similar to GetUsage(), but using only the
-// long flag if defined, the short flag otherwise.
-func (opt *T) GetCompletionUsage() (usage Description) {
-	var u strings.Builder
-	if opt.Long != "" {
-		fmt.Fprintf(&u, "--%v", opt.Long)
-	} else {
-		fmt.Fprintf(&u, "-%v", opt.Short)
-	}
-
-	if v := opt.getValueDescription(); v != "" {
-		if u.Len() > 0 {
-			u.WriteRune(' ')
-		}
-		u.WriteString(v)
-	}
-
-	return Description{
-		Option:      u.String(),
-		Description: opt.getDescription(),
-	}
-}
-
 func (opt *T) getValueDescription() string {
 	if opt.Type == Bool || opt.Type == Special {
 		return ""

--- a/pkg/option/option_test.go
+++ b/pkg/option/option_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/maargenton/go-errors"
 	"github.com/maargenton/go-testpredicate/pkg/require"
 	"github.com/maargenton/go-testpredicate/pkg/verify"
 
@@ -169,6 +170,25 @@ func TestOptionDescriptionUsage(t *testing.T) {
 				Args: true,
 			},
 			usage: "<args>...",
+		},
+		{
+			name: "a boolean Option",
+			opt: option.T{
+				Short: "d",
+				Long:  "debug",
+				Type:  option.Bool,
+			},
+			usage: "-d, --debug",
+		},
+		{
+			name: "a special Option",
+			opt: option.T{
+				Short:      "v",
+				Long:       "version",
+				Type:       option.Special,
+				SpecialErr: errors.Sentinel("ErrDisplayVersion"),
+			},
+			usage: "-v, --version",
 		},
 	}
 

--- a/sample/sercat-demo/main.go
+++ b/sample/sercat-demo/main.go
@@ -28,18 +28,19 @@ func (options *sercatCmd) Version() string {
 	return "sercat-demo v0.1.2"
 }
 
-var baudrateCompletion = cli.SimpleSuggestionList(
+var baudrateCompletion = []string{
 	"1200", "1800", "2400", "4800", "7200", "9600",
 	"14400", "19200", "28800", "38400", "57600", "76800",
 	"115200", "230400",
-)
-var formatCompletion = cli.SimpleSuggestionList(
+}
+
+var formatCompletion = []string{
 	"5N1", "6N1", "7N1", "8N1", "5N2", "6N2", "7N2", "8N2",
 	"5O1", "6O1", "7O1", "8O1", "5O2", "6O2", "7O2", "8O2",
 	"5E1", "6E1", "7E1", "8E1", "5E2", "6E2", "7E2", "8E2",
-)
+}
 
-func (options *sercatCmd) Complete(opt *option.T, partial string) []option.Description {
+func (options *sercatCmd) Complete(opt *option.T, partial string) []string {
 	if opt.Long == "baudrate" {
 		return baudrateCompletion
 	}
@@ -47,9 +48,9 @@ func (options *sercatCmd) Complete(opt *option.T, partial string) []option.Descr
 		return formatCompletion
 	}
 	if opt.Position == 1 {
-		return cli.FilepathCompletion("/dev/tty.*", partial)
+		return cli.MatchingFilenameCompletion(opt, "/dev/tty.*", partial)
 	}
-	return cli.DefaultCompletion(partial)
+	return cli.DefaultCompletion(opt, partial)
 }
 
 func (options *sercatCmd) Run() error {


### PR DESCRIPTION
- Handle completion options as a simple list of strings
- Simplify completion formatting and testing
- Change exposed completion methods to:
	- DefaultCompletion to expose the default completion behavior from a custom completion handler
	- DefaultFilenameCompletion matching default shell completion
	- MatchingFilenameCompletion for pattern based filename matching
- Handle zsh case where COMP_WORD is "--" for empty argument