### PR TITLE
Update build scripts, fix windows test issues

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,47 +1,48 @@
 name: build
-
 on: [push, pull_request]
 
 jobs:
-  test:
-    name: Tests
+  build:
+    name: Build
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         go:
-          - "1.17.x"
-          - "1.18.x"
+          - 1.17.x
+          - 1.18.x
+          - 1.19.x
+          - 1.20.x
         os:
           - ubuntu-latest
-          - macos-latest
+          - macos-12
           - windows-latest
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
-
-      - name: Install Go
-        uses: actions/setup-go@v2
+      - uses: actions/checkout@v3
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "2.5"
+      - uses: actions/setup-go@v3
         with:
           go-version: ${{ matrix.go }}
 
-      - name: Check version
-        run: go version
-
-      - name: Run tests with coverage
-        if: matrix.os != 'windows-latest'
-        run: go test -race -coverprofile=coverage.txt -covermode=atomic ./...
-
-      - name: Run tests without coverage (windows)
-        if: matrix.os == 'windows-latest'
-        run: go test -race ./...
+      - name: Test and build package
+        run: rake --trace build
 
       - name: Upload coverage
-        if: matrix.os != 'windows-latest'
-        uses: codecov/codecov-action@v2
+        if: matrix.os == 'ubuntu-latest' && matrix.go == '1.20.x'
+        uses: codecov/codecov-action@v3
         with:
           # token: ${{ secrets.CODECOV_TOKEN }}
           # fail_ci_if_error: true
           verbose: true
           flags: unittests
-          file: coverage.txt
+          file: build/go-test-coverage.txt
+
+      - name: Archive action artifacts
+        if: always() # Always run step even if other steps fail
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ matrix.os }}-${{ matrix.go }}
+          path: |
+            build/*

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,34 +5,33 @@ on:
       - v*
 
 jobs:
-  build:
+  release:
+    name: Release
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-ruby@v1
-      with:
-        ruby-version: '2.5'
-    - uses: actions/setup-go@v2
-      with:
-        go-version: 1.17
+      - uses: actions/checkout@v3
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "2.5"
+      - uses: actions/setup-go@v3
+        with:
+          go-version: 1.20.x
 
-    - name: Run tests
-      if: matrix.os == 'windows-latest'
-      run: go test -race ./...
+      - name: Test and build package
+        run: rake build
 
-    - name: Build and publish
-      run: rake build
+      - name: Archive action artifacts
+        if: always() # Always run step even if other steps fail
+        uses: actions/upload-artifact@v3
+        with:
+          name: release
+          path: |
+            build/*
 
-    # - name: Archive action artifacts
-    #   uses: actions/upload-artifact@v2
-    #   with:
-    #     name: artifacts
-    #     path: build/artifacts/*
-
-    - name: Upload artifacts to release
-      if: ${{ startsWith(github.ref, 'refs/tags/v') }}
-      uses: ncipollo/release-action@v1
-      with:
-        artifacts: "build/artifacts/*"
-        bodyFile: "build/release_notes"
-        token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload artifacts to release
+        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+        uses: ncipollo/release-action@v1
+        with:
+          artifacts: "build/artifacts/*"
+          bodyFile: "build/release_notes.md"
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A library to define command line interfaces in Go.
   https://img.shields.io/github/v/tag/maargenton/go-cli?color=blue&label=latest&logo=go&logoColor=white&sort=semver)](
   https://pkg.go.dev/github.com/maargenton/go-cli)
 [![Build](
-  https://img.shields.io/github/workflow/status/maargenton/go-cli/build?label=build&logo=github&logoColor=aaaaaa)](
+  https://img.shields.io/github/actions/workflow/status/maargenton/go-cli/build.yaml?branch=master&label=build&logo=github&logoColor=aaaaaa)](
   https://github.com/maargenton/go-cli/actions?query=branch%3Amaster)
 [![Codecov](
   https://img.shields.io/codecov/c/github/maargenton/go-cli?label=codecov&logo=codecov&logoColor=aaaaaa&token=1JFLIu042X)](

--- a/rakefile.rb
+++ b/rakefile.rb
@@ -13,34 +13,95 @@ require 'fileutils'
 
 task default: [:build]
 
-desc 'Display build information, including inferred verison number that uniquely identies the build product'
+WINDOWS=(RUBY_PLATFORM =~ /mswin|mingw|cygwin/)
+$stdout.sync = true
+
+desc 'Display build information'
 task :info do
-    puts "Name:    #{BuildInfo.default.name}"
-    puts "Version: #{BuildInfo.default.version}"
-    puts "Remote:  #{BuildInfo.default.remote}"
-    puts "Commit:  #{BuildInfo.default.commit}"
-    puts "Dir:     #{BuildInfo.default.dir}"
+    puts "Module:  #{GoBuild.default.gomod}"
+    puts "Version: #{GoBuild.default.version}"
+    puts "Source:  #{File.join(BuildInfo.default.remote,'tree',BuildInfo.default.commit[0,10])}"
+    # puts "Image:   #{File.basename(GoBuild.default.gomod)}"
+
+    summary = {
+        "Module" =>  GoBuild.default.gomod,
+        "Version" => GoBuild.default.version,
+        "Source" =>  File.join(BuildInfo.default.remote,'tree',BuildInfo.default.commit[0,10]),
+    }
+
+    # if GoBuild.default.targets.count > 0 then
+    #     puts "Main target: #{File.join('build/bin', GoBuild.default.main_target)}"
+    #     summary["Main Target"] = GoBuild.default.main_target
+
+    #     if GoBuild.default.targets.count > 1 then
+    #         targets = (GoBuild.default.targets.keys - [GoBuild.default.main_target])
+    #         puts "Additional targels:"
+    #         puts targets.map { |t| "  - #{File.join('build/bin',t)}" }.join(" \n")
+    #         summary["Additional Targets"] = targets
+    #     end
+    # end
+
+    record_summary("## Build summary\n\n#{format_summary_table(summary)}\n")
 end
 
-desc 'Display inferred build version number'
+
+desc 'Display inferred build version string'
 task :version do
-    puts BuildInfo.default.version
+    puts GoBuild.default.version
+end
+
+
+desc 'Run all tests and capture results'
+task :test => [:info] do
+    FileUtils.makedirs( ['./build/artifacts'] )
+    success = go_test()
+    go_testreport('build/go-test-result.json',
+        '--md-shift-headers=1',
+        '-oyaml=build/artifacts/test-report.yaml',
+        '-omd=build/artifacts/test-report.md',
+        '-omdsf=build/go-test-summary.md',
+        '-omdsfd=build/go-test-details.md',
+    )
+
+    puts File.read('build/go-test-summary.md')
+    record_summary(File.read('build/go-test-details.md'))
+
+    exit(1) if !success
 end
 
 desc 'Build and publish both release archive and associated container image'
-task :build do
-    FileUtils.makedirs( ['./build/artifacts'] )
-    version = BuildInfo.default.version
-    puts "Version: #{version}"
-    File.write( 'build/release_notes',  generate_release_notes(version,
-        # prefix: "go-cli",
-        input:'RELEASES.md',
-    ))
+task :build => [:info, :test] do
+    # Nothing to do here
+    generate_release_notes()
 end
 
 desc 'Remove build artifacts'
 task :clean do
     FileUtils.rm_rf('./build')
+end
+
+
+def go_test()
+    FileUtils.makedirs( ['./build'] )
+    cmd = "go test #{WINDOWS ? "" : "-race "}" +
+        "-coverprofile=build/go-test-coverage.txt -covermode=atomic " +
+        "-json ./... > build/go-test-result.json"
+    system(cmd)
+end
+
+def go_testreport(*args)
+    cmd = %w{go run github.com/maargenton/go-testreport@v0.1.6}
+    # cmd = %w{go run main.go} # use local
+    cmd += args
+    system(*cmd)
+end
+
+def generate_release_notes()
+    version = BuildInfo.default.version
+    File.write( 'build/release_notes.md',  extract_release_notes(version,
+        # prefix: "go-testreport",
+        input:'RELEASES.md',
+    ))
 end
 
 
@@ -57,7 +118,7 @@ class BuildInfo
     def initialize()
         if _git('rev-parse --is-shallow-repository') == 'true'
             puts "Fetching missing information from remote ..."
-            system(' git fetch --prune --tags --unshallow')
+            system('git fetch --prune --tags --unshallow')
         end
     end
 
@@ -68,7 +129,7 @@ class BuildInfo
     def dir()       return @dir     ||= _dir()      end
 
     private
-    def _git( cmd ) return `git #{cmd} 2>/dev/null`.strip()     end
+    def _git( cmd ) return `git #{cmd} #{WINDOWS ? "2>nul" : "2>/dev/null"}`.strip() end
     def _commit()   return _git('rev-parse HEAD')               end
     def _dir()      return _git('rev-parse --show-toplevel')    end
 
@@ -91,7 +152,8 @@ class BuildInfo
         # Note: Due to glob(7) limitations, the following pattern enforces
         # 3-part dot-separated sequences starting with a digit,
         # rather than 3 dot-separated numbers.
-        d = _git("describe --always --tags --long  --match 'v[0-9]*.[0-9]*.[0-9]*'").strip.split('-')
+        pattern = WINDOWS ? '"v[0-9]*.[0-9]*.[0-9]*"' : "'v[0-9]*.[0-9]*.[0-9]*'"
+        d = _git("describe --always --tags --long --match #{pattern}").strip.split('-')
         if d.count != 0
             b = _git("rev-parse --abbrev-ref HEAD").strip.gsub(/[^A-Za-z0-9\._-]+/, '-')
             return ['v0.0.0', b, _git("rev-list --count HEAD").strip.to_i, "g#{d[0]}"] if d.count == 1
@@ -146,10 +208,141 @@ end
 
 
 # ----------------------------------------------------------------------------
+# GoBuild : Helper to build go projects
+# ----------------------------------------------------------------------------
+
+class GoBuild
+    class << self
+        def default() return @default ||= new end
+    end
+
+    def initialize( buildinfo = nil )
+        @buildinfo = buildinfo || BuildInfo.default
+    end
+
+    def gomod()         return @gomod       ||= _gomod()            end
+    def targets()       return @tagets      ||= _targets()          end
+    def main_target()   return @main_target ||= _main_target()      end
+    def version()       return @version     ||= @buildinfo.version  end
+    def ldflags()       return @ldflags     ||= _ldflags()          end
+
+    def commands(action = 'build')
+        flags = %Q{"#{ldflags}"}
+        Hash[targets.map do |name, input|
+            output = File.join( './build/bin', name )
+            cmd = [ "go #{action} -trimpath -ldflags #{flags}",
+                ("-o #{output}" if action == 'build'),
+                "#{input}"
+            ].compact.join(' ')
+            [name, cmd]
+        end]
+    end
+
+private
+    def _gomod()
+        return '' if !File.readable?('go.mod')
+        File.foreach('go.mod') do |l|
+            return l[7..-1].strip if l.start_with?( 'module ' )
+        end
+    end
+
+    def _targets()
+        targets = Hash[Dir["./cmd/**/main.go"].map do |f|
+            path = File.dirname(f)
+            [File.basename(path), File.join( path, "..." )]
+        end]
+        targets[File.basename(gomod)] = "." if File.exist?("./main.go")
+        targets
+    end
+
+    def _ldflags()
+        prefix = "#{gomod}/pkg/buildinfo"
+        {   Version: @buildinfo.version,
+            GitHash: @buildinfo.commit,
+            GitRepo: @buildinfo.remote,
+            BuildRoot: @buildinfo.dir
+        }.map { |k,v| "-X #{prefix}.#{k}=#{v}"}.join(' ')
+    end
+
+    def _main_target()
+        mod = File.basename(gomod)
+        targets.keys.min_by{ |v| _lev(v, mod)}
+    end
+
+    def _lev(a, b, memo={})
+        return b.size if a.empty?
+        return a.size if b.empty?
+        return memo[[a, b]] ||= [
+            _lev(a.chop, b, memo) + 1,
+            _lev(a, b.chop, memo) + 1,
+            _lev(a.chop, b.chop, memo) + (a[-1] == b[-1] ? 0 : 1)
+        ].min
+    end
+end
+
+
+
+# ----------------------------------------------------------------------------
+# DockerHelper : Helper to build go projects
+# ----------------------------------------------------------------------------
+
+def docker_registry_tags(base_tag)
+    return [github_registry_tag(base_tag)]
+end
+
+def github_registry_tag(base_tag)
+    return if ENV['GITHUB_ACTOR'].nil? || ENV['GITHUB_REPOSITORY'].nil?
+    if ENV['GITHUB_TOKEN'].nil? then
+        puts "Found GitHub Actiona context but no 'GITHUB_TOKEN'."
+        puts "Image will not be pushed to GitHub package registry."
+        puts "To resolve this issue, add the following to your workflow:"
+        puts "  env:"
+        puts "    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}"
+        return
+    end
+    # Authenticate
+    puts "Authenticating with docker.pkg.github.com..."
+    system("echo ${GITHUB_TOKEN} | docker login ghcr.io --username ${GITHUB_ACTOR} --password-stdin")
+    puts "Failed to authenticate with docker.pkg.github.com" if $?.exitstatus != 0
+
+    return File.join('ghcr.io', ENV['GITHUB_REPOSITORY_OWNER'], base_tag)
+end
+
+
+
+# ----------------------------------------------------------------------------
+# Build summary generator
+# ----------------------------------------------------------------------------
+
+def record_summary(content)
+    return if ENV['GITHUB_STEP_SUMMARY'].nil?
+    summary_filename = ENV['GITHUB_STEP_SUMMARY']
+    open(summary_filename, 'a') do |f|
+        f.puts content
+    end
+end
+
+def format_summary_table(summary)
+    o = "| | |\n|-|-|\n"
+    summary.each do |key, value|
+        if value.respond_to?('each')
+            value.each_with_index do |v, i|
+                o += (i == 0) ? "| #{key} | `#{v}`\n" : "| | `#{v}`\n"
+            end
+        else
+            o += "| #{key} | `#{value}`\n"
+        end
+    end
+    return o
+end
+
+
+
+# ----------------------------------------------------------------------------
 # Release notes generator
 # ----------------------------------------------------------------------------
 
-def generate_release_notes(version, prefix:nil, input:nil, checksums:nil)
+def extract_release_notes(version, prefix:nil, input:nil, checksums:nil)
     rn = ""
     rn += "#{prefix} #{version}\n\n" if prefix
     rn += load_release_notes(input, version) if input


### PR DESCRIPTION
- Update rakefile and workflows (from maargnton/go-testreport)
- Upload coverage file on linux runner, latest go only
- Fix build badge in README.md
- Fix Ruby STDOUT buffering on windows
- Disable `-race` option when running tests on windows
- Use proper shell escaping.for `git describe` on windows
- Remove extra leading space in `git unshallow` command