### PR TITLE
Add missing support for default values in positional arguments

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Archive action artifacts
         if: always() # Always run step even if other steps fail
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.os }}-${{ matrix.go }}
           path: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -19,9 +19,6 @@ jobs:
           - windows-latest
     steps:
       - uses: actions/checkout@v3
-      # - uses: ruby/setup-ruby@v1
-      #   with:
-      #     ruby-version: "2.5"
       - uses: actions/setup-go@v3
         with:
           go-version: ${{ matrix.go }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -19,9 +19,9 @@ jobs:
           - windows-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: "2.5"
+      # - uses: ruby/setup-ruby@v1
+      #   with:
+      #     ruby-version: "2.5"
       - uses: actions/setup-go@v3
         with:
           go-version: ${{ matrix.go }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,7 +15,7 @@ jobs:
           - 1.20.x
         os:
           - ubuntu-latest
-          - macos-12
+          - macos-latest
           - windows-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Archive action artifacts
         if: always() # Always run step even if other steps fail
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: release
           path: |

--- a/pkg/option/optionset.go
+++ b/pkg/option/optionset.go
@@ -80,11 +80,17 @@ func (opts *Set) AddSpecialFlag(short, long, desc string, err error) {
 	opts.Options = append(opts.Options, opt)
 }
 
-// ApplyDefaults scans through a parsed option set and applies the values
-// defined in the environment to the fields backed by a matching environment
-// variable.
+// ApplyDefaults scans through a parsed option set and applies the corresponding
+// default values to the fields of the target struct value.
 func (opts *Set) ApplyDefaults() error {
 	for _, opt := range opts.Options {
+		if opt.Default != "" {
+			if err := opt.SetValue(opt.Default); err != nil {
+				return fmt.Errorf("while applying defaults, %w", err)
+			}
+		}
+	}
+	for _, opt := range opts.Positional {
 		if opt.Default != "" {
 			if err := opt.SetValue(opt.Default); err != nil {
 				return fmt.Errorf("while applying defaults, %w", err)
@@ -94,8 +100,9 @@ func (opts *Set) ApplyDefaults() error {
 	return nil
 }
 
-// ApplyEnv scans through a parsed option set and applies the corresponding
-// default values to the fields of the target struct value.
+// ApplyEnv scans through a parsed option set and applies the values
+// defined in the environment to the fields backed by a matching environment
+// variable.
 func (opts *Set) ApplyEnv(env map[string]string) error {
 	for _, opt := range opts.Options {
 		if opt.Env != "" {
@@ -302,7 +309,7 @@ func (opts *Set) parseStruct() error {
 	// positional as optional.
 	for i := len(opts.Positional) - 1; i >= 0; i-- {
 		arg := opts.Positional[i]
-		if arg.FieldType.Kind() == reflect.Ptr {
+		if arg.FieldType.Kind() == reflect.Ptr || arg.Default != "" {
 			arg.Optional = true
 		} else {
 			break

--- a/pkg/option/optionset_test.go
+++ b/pkg/option/optionset_test.go
@@ -564,7 +564,7 @@ func TestApplyArgs_NonFlagArguments(t *testing.T) {
 		A bool          `opts:"-a, --aaa"`
 		D time.Duration `opts:"-d, --duration"`
 		U string        `opts:"arg:1"`
-		V string        `opts:"arg:2"`
+		V string        `opts:"arg:2, default:ddd"`
 		W []string      `opts:"args"`
 	}
 	var tcs = []struct {
@@ -581,6 +581,15 @@ func TestApplyArgs_NonFlagArguments(t *testing.T) {
 				W: []string{"ccc", "ddd"},
 			},
 		},
+		{
+			[]string{"--aaa", "--duration", "5m", "aaa"},
+			command{
+				A: true,
+				D: 5 * time.Minute,
+				U: "aaa",
+				V: "ddd",
+			},
+		},
 	}
 
 	for _, tc := range tcs {
@@ -588,6 +597,9 @@ func TestApplyArgs_NonFlagArguments(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			var cmd command
 			optionSet, err := option.NewOptionSet(&cmd)
+			require.That(t, err).IsNil()
+
+			err = optionSet.ApplyDefaults()
 			require.That(t, err).IsNil()
 
 			err = optionSet.ApplyArgs(tc.args)
@@ -647,6 +659,17 @@ func TestApplyArgs_NonFlagArguments_Errors(t *testing.T) {
 			}{},
 			"failed to set value",
 		},
+		{
+			[]string{"--aaa", "1", "2", "ccc"},
+			&struct {
+				A bool          `opts:"-a, --aaa"`
+				D time.Duration `opts:"-d, --duration"`
+				U int           `opts:"arg:1"`
+				V int           `opts:"arg:2, default:foo"`
+				W []int         `opts:"args"`
+			}{},
+			"failed to set value",
+		},
 	}
 
 	for _, tc := range tcs {
@@ -656,8 +679,13 @@ func TestApplyArgs_NonFlagArguments_Errors(t *testing.T) {
 			optionSet, err := option.NewOptionSet(tc.cmd)
 			require.That(t, err).IsNil()
 
-			err = optionSet.ApplyArgs(tc.args)
-			require.That(t, err).ToString().Contains(tc.err)
+			err = optionSet.ApplyDefaults()
+			if err != nil {
+				require.That(t, err).ToString().Contains(tc.err)
+			} else {
+				err = optionSet.ApplyArgs(tc.args)
+				require.That(t, err).ToString().Contains(tc.err)
+			}
 		})
 	}
 }


### PR DESCRIPTION
- Apply default values to positional arguments as well in `ApplyDefaults()`
- Mark trailing positional arguments with default value as optional
- Fix mismatch comments between `ApplyDefaults()` and `ApplyEnv()`